### PR TITLE
Appdev 9066 updated revisionable custom fork

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,12 @@
+This custom fork replicates the custom changes from the original UNC revisionable [fork](https://github.com/UNC-Libraries/revisionable) onto an updated fork of Revisionable. 
+It will only work with [Jitterbug](https://github.com/UNC-Libraries/jitterbug).
+
+Added features:
+* "key" changed to "field"
+* adding transaction ID and IP address recording
+* getting the class basename in one instance
+* support for soft deleted foreign keys
+
 <img src="https://cdn1.wwe.com/static/ossimg/revisionableghbanner.png" style="width: 100%" alt="Revisionable for Laravel" />
 
 [![Laravel 4.x](https://img.shields.io/badge/Laravel-4.x-yellow.svg?style=flat-square)](https://laravel.com/)

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -148,7 +148,12 @@ class Revision extends Eloquent
 
                     // Finally, now that we know the namespace of the related model
                     // we can load it, to find the information we so desire
-                    $item = $related_class::find($this->$which_value);
+                    $item;
+                    if (array_key_exists('Illuminate\Database\Eloquent\SoftDeletes', class_uses($related_class))) {
+                      $item = $related_class::withTrashed()->find($this->$which_value);
+                    } else {
+                      $item = $related_class::find($this->$which_value);
+                    }
 
                     if (is_null($this->$which_value) || $this->$which_value == '') {
                         $item = new $related_class;

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -169,7 +169,7 @@ class Revision extends Eloquent
                     // Check if model use RevisionableTrait
                     if(method_exists($item, 'identifiableName')) {
                         // see if there's an available mutator
-                        $mutator = 'get' . Str::studly($this->field . 'Attribute';
+                        $mutator = 'get' . Str::studly($this->field) . 'Attribute';
                         if (method_exists($item, $mutator)) {
                             return $this->format($item->$mutator($this->field), $item->identifiableName());
                         }

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -180,7 +180,8 @@ class Revision extends Eloquent
             // if there was an issue
             // or, if it's a normal value
 
-            $mutator = 'get' . Str::studly($this->field) . 'Attribute';
+            // the accessor method is called getFieldDisplayAttribute in JB
+            $mutator = 'get' . Str::studly($this->field) . 'DisplayAttribute';
             if (method_exists($main_model, $mutator)) {
                 return $this->format($this->field, $main_model->$mutator($this->$which_value));
             }

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -56,12 +56,12 @@ class Revision extends Eloquent
      */
     public function fieldName()
     {
-        if ($formatted = $this->formatFieldName($this->key)) {
+        if ($formatted = $this->formatFieldName($this->field)) {
             return $formatted;
-        } elseif (strpos($this->key, '_id')) {
-            return str_replace('_id', '', $this->key);
+        } elseif (strpos($this->field, '_id')) {
+            return str_replace('_id', '', $this->field);
         } else {
-            return $this->key;
+            return $this->field;
         }
     }
 
@@ -158,18 +158,18 @@ class Revision extends Eloquent
                     if (!$item) {
                         $item = new $related_class;
 
-                        return $this->format($this->key, $item->getRevisionUnknownString());
+                        return $this->format($this->field, $item->getRevisionUnknownString());
                     }
 
                     // Check if model use RevisionableTrait
                     if(method_exists($item, 'identifiableName')) {
                         // see if there's an available mutator
-                        $mutator = 'get' . Str::studly($this->key) . 'Attribute';
+                        $mutator = 'get' . Str::studly($this->field . 'Attribute';
                         if (method_exists($item, $mutator)) {
-                            return $this->format($item->$mutator($this->key), $item->identifiableName());
+                            return $this->format($item->$mutator($this->field), $item->identifiableName());
                         }
 
-                        return $this->format($this->key, $item->identifiableName());
+                        return $this->format($this->field, $item->identifiableName());
                     }
                 }
             } catch (\Exception $e) {
@@ -180,13 +180,13 @@ class Revision extends Eloquent
             // if there was an issue
             // or, if it's a normal value
 
-            $mutator = 'get' . Str::studly($this->key) . 'Attribute';
+            $mutator = 'get' . Str::studly($this->field) . 'Attribute';
             if (method_exists($main_model, $mutator)) {
-                return $this->format($this->key, $main_model->$mutator($this->$which_value));
+                return $this->format($this->field, $main_model->$mutator($this->$which_value));
             }
         }
 
-        return $this->format($this->key, $this->$which_value);
+        return $this->format($this->field, $this->$which_value);
     }
 
     /**
@@ -198,10 +198,10 @@ class Revision extends Eloquent
     {
         $isRelated = false;
         $idSuffix = '_id';
-        $pos = strrpos($this->key, $idSuffix);
+        $pos = strrpos($this->field, $idSuffix);
 
         if ($pos !== false
-            && strlen($this->key) - strlen($idSuffix) === $pos
+            && strlen($this->field) - strlen($idSuffix) === $pos
         ) {
             $isRelated = true;
         }
@@ -218,7 +218,7 @@ class Revision extends Eloquent
     {
         $idSuffix = '_id';
 
-        return substr($this->key, 0, strlen($this->key) - strlen($idSuffix));
+        return substr($this->field, 0, strlen($this->field) - strlen($idSuffix));
     }
 
     /**

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -70,18 +70,18 @@ class Revision extends Eloquent
      *
      * Allow overrides for field names.
      *
-     * @param $key
+     * @param $field
      *
      * @return bool
      */
-    private function formatFieldName($key)
+    private function formatFieldName($field)
     {
         $related_model = $this->getActualClassNameForMorph($this->revisionable_type);
         $related_model = new $related_model;
         $revisionFormattedFieldNames = $related_model->getRevisionFormattedFieldNames();
 
-        if (isset($revisionFormattedFieldNames[$key])) {
-            return $revisionFormattedFieldNames[$key];
+        if (isset($revisionFormattedFieldNames[$field])) {
+            return $revisionFormattedFieldNames[$field];
         }
 
         return false;
@@ -273,19 +273,19 @@ class Revision extends Eloquent
     /**
      * Format the value according to the $revisionFormattedFields array.
      *
-     * @param  $key
+     * @param  $field
      * @param  $value
      *
      * @return string formatted value
      */
-    public function format($key, $value)
+    public function format($field, $value)
     {
         $related_model = $this->getActualClassNameForMorph($this->revisionable_type);
         $related_model = new $related_model;
         $revisionFormattedFields = $related_model->getRevisionFormattedFields();
 
-        if (isset($revisionFormattedFields[$key])) {
-            return FieldFormatter::format($key, $value, $revisionFormattedFields);
+        if (isset($revisionFormattedFields[$field])) {
+            return FieldFormatter::format($field, $value, $revisionFormattedFields);
         } else {
             return $value;
         }

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -153,7 +153,7 @@ class Revisionable extends Eloquent
                 $revisions[] = array(
                     'revisionable_type'     => $this->getMorphClass(),
                     'revisionable_id'       => $this->getKey(),
-                    'key'                   => $key,
+                    'field'                   => $key,
                     'old_value'             => Arr::get($this->originalData, $key),
                     'new_value'             => $this->updatedData[$key],
                     'user_id'               => $this->getSystemUserId(),
@@ -188,7 +188,7 @@ class Revisionable extends Eloquent
             $revisions[] = array(
                 'revisionable_type' => $this->getMorphClass(),
                 'revisionable_id' => $this->getKey(),
-                'key' => self::CREATED_AT,
+                'field' => self::CREATED_AT,
                 'old_value' => null,
                 'new_value' => $this->{self::CREATED_AT},
                 'user_id' => $this->getSystemUserId(),
@@ -212,7 +212,7 @@ class Revisionable extends Eloquent
             $revisions[] = array(
                 'revisionable_type' => $this->getMorphClass(),
                 'revisionable_id' => $this->getKey(),
-                'key' => $this->getDeletedAtColumn(),
+                'field' => $this->getDeletedAtColumn(),
                 'old_value' => null,
                 'new_value' => $this->{$this->getDeletedAtColumn()},
                 'user_id' => $this->getSystemUserId(),

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -153,7 +153,9 @@ class Revisionable extends Eloquent
                 $revisions[] = array(
                     'revisionable_type'     => $this->getMorphClass(),
                     'revisionable_id'       => $this->getKey(),
-                    'field'                   => $key,
+                    'transaction_id'        => $this->getTransactionId(),
+                    'ip_address'            => \Request::ip(),
+                    'field'                 => $key,
                     'old_value'             => Arr::get($this->originalData, $key),
                     'new_value'             => $this->updatedData[$key],
                     'user_id'               => $this->getSystemUserId(),
@@ -188,6 +190,8 @@ class Revisionable extends Eloquent
             $revisions[] = array(
                 'revisionable_type' => $this->getMorphClass(),
                 'revisionable_id' => $this->getKey(),
+                'transaction_id'        => $this->getTransactionId(),
+                'ip_address'            => \Request::ip(),
                 'field' => self::CREATED_AT,
                 'old_value' => null,
                 'new_value' => $this->{self::CREATED_AT},
@@ -212,6 +216,8 @@ class Revisionable extends Eloquent
             $revisions[] = array(
                 'revisionable_type' => $this->getMorphClass(),
                 'revisionable_id' => $this->getKey(),
+                'transaction_id'        => $this->getTransactionId(),
+                'ip_address'            => \Request::ip(),
                 'field' => $this->getDeletedAtColumn(),
                 'old_value' => null,
                 'new_value' => $this->{$this->getDeletedAtColumn()},

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -301,7 +301,7 @@ trait RevisionableTrait
 
     /**
      * Get the transaction that this revision is a part of. This value
-     * should be set from within the transaction block while saving
+     * is set from within the transaction block in Jitterbug while saving
      * your revisionable model.
      **/
     public function getTransactionId()

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -105,7 +105,7 @@ trait RevisionableTrait
     public static function classRevisionHistory($limit = 100, $order = 'desc')
     {
         $model = Revisionable::newModel();
-        return $model->where('revisionable_type', get_called_class())
+        return $model->where('revisionable_type', class_basename(get_called_class()))
             ->orderBy('updated_at', $order)->limit($limit)->get();
     }
 

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -189,7 +189,7 @@ trait RevisionableTrait
                 $revisions[] = array(
                     'revisionable_type' => $this->getMorphClass(),
                     'revisionable_id' => $this->getKey(),
-                    'key' => $key,
+                    'field' => $key,
                     'old_value' => Arr::get($this->originalData, $key),
                     'new_value' => $this->updatedData[$key],
                     'user_id' => $this->getSystemUserId(),
@@ -231,7 +231,7 @@ trait RevisionableTrait
             $revisions[] = array(
                 'revisionable_type' => $this->getMorphClass(),
                 'revisionable_id' => $this->getKey(),
-                'key' => self::CREATED_AT,
+                'field' => self::CREATED_AT,
                 'old_value' => null,
                 'new_value' => $this->{self::CREATED_AT},
                 'user_id' => $this->getSystemUserId(),
@@ -258,7 +258,7 @@ trait RevisionableTrait
             $revisions[] = array(
                 'revisionable_type' => $this->getMorphClass(),
                 'revisionable_id' => $this->getKey(),
-                'key' => $this->getDeletedAtColumn(),
+                'field' => $this->getDeletedAtColumn(),
                 'old_value' => null,
                 'new_value' => $this->{$this->getDeletedAtColumn()},
                 'user_id' => $this->getSystemUserId(),

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -189,6 +189,8 @@ trait RevisionableTrait
                 $revisions[] = array(
                     'revisionable_type' => $this->getMorphClass(),
                     'revisionable_id' => $this->getKey(),
+                    'transaction_id'        => $this->getTransactionId(),
+                    'ip_address'            => \Request::ip(),
                     'field' => $key,
                     'old_value' => Arr::get($this->originalData, $key),
                     'new_value' => $this->updatedData[$key],
@@ -231,6 +233,8 @@ trait RevisionableTrait
             $revisions[] = array(
                 'revisionable_type' => $this->getMorphClass(),
                 'revisionable_id' => $this->getKey(),
+                'transaction_id'        => $this->getTransactionId(),
+                'ip_address'            => \Request::ip(),
                 'field' => self::CREATED_AT,
                 'old_value' => null,
                 'new_value' => $this->{self::CREATED_AT},
@@ -258,6 +262,8 @@ trait RevisionableTrait
             $revisions[] = array(
                 'revisionable_type' => $this->getMorphClass(),
                 'revisionable_id' => $this->getKey(),
+                'transaction_id'        => $this->getTransactionId(),
+                'ip_address'            => \Request::ip(),
                 'field' => $this->getDeletedAtColumn(),
                 'old_value' => null,
                 'new_value' => $this->{$this->getDeletedAtColumn()},
@@ -291,6 +297,16 @@ trait RevisionableTrait
         }
 
         return null;
+    }
+
+    /**
+     * Get the transaction that this revision is a part of. This value
+     * should be set from within the transaction block while saving
+     * your revisionable model.
+     **/
+    public function getTransactionId()
+    {
+      return \DB::select('select @transaction_id as id;')[0]->id;
     }
 
     /**
@@ -329,7 +345,9 @@ trait RevisionableTrait
      */
     private function isRevisionable($key)
     {
-
+        if ($field === 'updated_at') {
+          return false;
+        }
         // If the field is explicitly revisionable, then return true.
         // If it's explicitly not revisionable, return false.
         // Otherwise, if neither condition is met, only return true if

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -345,7 +345,7 @@ trait RevisionableTrait
      */
     private function isRevisionable($key)
     {
-        if ($field === 'updated_at') {
+        if ($key === 'updated_at') {
           return false;
         }
         // If the field is explicitly revisionable, then return true.

--- a/src/migrations/2013_04_09_062329_create_revisions_table.php
+++ b/src/migrations/2013_04_09_062329_create_revisions_table.php
@@ -15,6 +15,8 @@ class CreateRevisionsTable extends Migration
             $table->increments('id');
             $table->string('revisionable_type');
             $table->integer('revisionable_id');
+            $table->string('transaction_id');
+            $table->string('ip_address');
             $table->integer('user_id')->nullable();
             $table->string('field');
             $table->text('old_value')->nullable();

--- a/src/migrations/2013_04_09_062329_create_revisions_table.php
+++ b/src/migrations/2013_04_09_062329_create_revisions_table.php
@@ -16,7 +16,7 @@ class CreateRevisionsTable extends Migration
             $table->string('revisionable_type');
             $table->integer('revisionable_id');
             $table->integer('user_id')->nullable();
-            $table->string('key');
+            $table->string('field');
             $table->text('old_value')->nullable();
             $table->text('new_value')->nullable();
             $table->timestamps();


### PR DESCRIPTION
This PR replicates the custom changes from the original UNC revisionable [fork](https://github.com/UNC-Libraries/revisionable) onto an updated fork of [Revisionable](https://github.com/VentureCraft/revisionable)

- "key" changed to "field"
- adding transaction ID and IP address recording
- getting the class basename in one instance (if i remember correctly, the other instances are not needed because the updated Revisionable uses `getMorph` instead of `get_class` which automatically gets the basename)
- support for soft deleted foreign keys