### PR TITLE
Appdev 9849 update jb to laravel 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor
 composer.lock
+/.idea
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~4.0|~5.0|~5.1|^6.0|^7.0",
-        "laravel/framework": "~5.4|^6.0|^7.0"
+        "illuminate/support": "~4.0|~5.0|~5.1|^6.0|^7.0|^8.0",
+        "laravel/framework": "~5.4|^6.0|^7.0|^8.0"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~4.0|~5.0|~5.1|^6.0",
-        "laravel/framework": "~5.4|^6.0"
+        "illuminate/support": "~4.0|~5.0|~5.1|^6.0|^7.0",
+        "laravel/framework": "~5.4|^6.0|^7.0"
     },
     "autoload": {
         "classmap": [

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,5 @@
 <img src="https://cdn1.wwe.com/static/ossimg/revisionableghbanner.png" style="width: 100%" alt="Revisionable for Laravel" />
 
-[![Laravel 4.x](https://img.shields.io/badge/Laravel-4.x-yellow.svg?style=flat-square)](https://laravel.com/)
-[![Laravel 5.2](https://img.shields.io/badge/Laravel-5.x-brightgreen.svg?style=flat-square)](https://laravel.com/)
 [![Latest Version](https://img.shields.io/github/release/venturecraft/revisionable.svg?style=flat-square)](https://packagist.org/packages/venturecraft/revisionable)
 [![Downloads](https://img.shields.io/packagist/dt/venturecraft/revisionable.svg?style=flat-square)](https://packagist.org/packages/venturecraft/revisionable)
 [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](https://tldrlegal.com/license/mit-license)

--- a/readme.md
+++ b/readme.md
@@ -162,6 +162,14 @@ To better format the output for `deleted_at` entries, you can use the `isEmpty` 
 
 <a name="control"></a>
 
+### Storing Force Delete
+By default the Force Delete of a model is not stored as a revision.
+
+If you want to store the Force Delete as a revision you can override this behavior by setting `revisionForceDeleteEnabled ` to `true` by adding the following to your model:
+```php
+protected $revisionForceDeleteEnabled = true;
+```
+
 ### Storing Creations
 By default the creation of a new model is not stored as a revision.
 Only subsequent changes to a model is stored.

--- a/readme.md
+++ b/readme.md
@@ -187,6 +187,21 @@ protected $dontKeepRevisionOf = ['category_id'];
 
 > The `$keepRevisionOf` setting takes precedence over `$dontKeepRevisionOf`
 
+### Storing additional fields in revisions
+
+In some cases, you'll want additional metadata from the models in each revision. An example of this might be if you 
+have to keep track of accounts as well as users. Simply create a migration to add the fields you'd like to your revision model,
+add them to your config/revisionable.php separated by pipes like so:
+
+```php 
+'additional_fields_in_model' => "account_id|permissions_id|other_id", 
+```
+
+If the column exists in the model, it will be included in the revision. 
+
+Make sure that if you can't guarantee the column in every model, you make that column ```nullable()``` in your migrations.  
+
+
 ### Events
 
 Every time a model revision is created an event is fired. You can listen for `revisionable.created`,  

--- a/readme.md
+++ b/readme.md
@@ -170,7 +170,7 @@ If you want to store the Force Delete as a revision you can override this behavi
 protected $revisionForceDeleteEnabled = true;
 ```
 
-In which case, the `created_at` field will be stored as a key with the `oldValue()` value equal to the model creation date and the `newValue()` value equal to null.
+In which case, the `created_at` field will be stored as a key with the `oldValue()` value equal to the model creation date and the `newValue()` value equal to `null`.
 
 **Attention!** Turn on this setting carefully! Since the model saved in the revision, now does not exist, so you will not be able to get its object or its relations. 
 

--- a/readme.md
+++ b/readme.md
@@ -190,11 +190,11 @@ protected $dontKeepRevisionOf = ['category_id'];
 ### Storing additional fields in revisions
 
 In some cases, you'll want additional metadata from the models in each revision. An example of this might be if you 
-have to keep track of accounts as well as users. Simply create a migration to add the fields you'd like to your revision model,
-add them to your config/revisionable.php separated by pipes like so:
+have to keep track of accounts as well as users. Simply create your own new migration to add the fields you'd like to your revision model,
+add them to your config/revisionable.php in an array like so:
 
 ```php 
-'additional_fields_in_model' => "account_id|permissions_id|other_id", 
+'additional_fields' => ['account_id', 'permissions_id', 'other_id'], 
 ```
 
 If the column exists in the model, it will be included in the revision. 

--- a/readme.md
+++ b/readme.md
@@ -170,6 +170,10 @@ If you want to store the Force Delete as a revision you can override this behavi
 protected $revisionForceDeleteEnabled = true;
 ```
 
+In which case, the `created_at` field will be stored as a key with the `oldValue()` value equal to the model creation date and the `newValue()` value equal to null.
+
+**Attention!** Turn on this setting carefully! Since the model saved in the revision, now does not exist, so you will not be able to get its object or its relations. 
+
 ### Storing Creations
 By default the creation of a new model is not stored as a revision.
 Only subsequent changes to a model is stored.

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -234,6 +234,8 @@ class Revisionable extends Eloquent
             if (class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')
                     || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')) {
                 return ($class::check()) ? $class::getUser()->id : null;
+            } elseif (function_exists('backpack_auth') && backpack_auth()->check()) {
+                return backpack_user()->id;
             } elseif (\Auth::check()) {
                 return \Auth::user()->getAuthIdentifier();
             }

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -72,6 +72,7 @@ class Revisionable extends Eloquent
         static::deleted(function ($model) {
             $model->preSave();
             $model->postDelete();
+            $model->postForceDelete();
         });
     }
     /**
@@ -221,6 +222,37 @@ class Revisionable extends Eloquent
             );
             $revision = static::newModel();
             \DB::table($revision->getTable())->insert($revisions);
+        }
+    }
+
+    /**
+     * If forcedeletes are enabled, set the value created_at of model to null
+     *
+     * @return void|bool
+     */
+    public function postForceDelete()
+    {
+        if (empty($this->revisionForceDeleteEnabled)) {
+            return false;
+        }
+
+        if ((!isset($this->revisionEnabled) || $this->revisionEnabled)
+            && (($this->isSoftDelete() && $this->isForceDeleting()) || !$this->isSoftDelete())) {
+
+            $revisions[] = array(
+                'revisionable_type' => $this->getMorphClass(),
+                'revisionable_id' => $this->getKey(),
+                'key' => self::CREATED_AT,
+                'old_value' => $this->{self::CREATED_AT},
+                'new_value' => null,
+                'user_id' => $this->getSystemUserId(),
+                'created_at' => new \DateTime(),
+                'updated_at' => new \DateTime(),
+            );
+
+            $revision = Revisionable::newModel();
+            \DB::table($revision->getTable())->insert($revisions);
+            \Event::dispatch('revisionable.deleted', array('model' => $this, 'revisions' => $revisions));
         }
     }
 

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -248,7 +248,9 @@ class Revisionable extends Eloquent
             $revisions[] = array(
                 'revisionable_type' => $this->getMorphClass(),
                 'revisionable_id' => $this->getKey(),
-                'key' => self::CREATED_AT,
+                'transaction_id'        => $this->getTransactionId(),
+                'ip_address'            => \Request::ip(),
+                'field' => self::CREATED_AT,
                 'old_value' => $this->{self::CREATED_AT},
                 'new_value' => null,
                 'user_id' => $this->getSystemUserId(),

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -306,7 +306,9 @@ trait RevisionableTrait
             $revisions[] = array(
                 'revisionable_type' => $this->getMorphClass(),
                 'revisionable_id' => $this->getKey(),
-                'key' => self::CREATED_AT,
+                'transaction_id'        => $this->getTransactionId(),
+                'ip_address'            => \Request::ip(),
+                'field' => self::CREATED_AT,
                 'old_value' => $this->{self::CREATED_AT},
                 'new_value' => null,
                 'user_id' => $this->getSystemUserId(),

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -309,35 +309,14 @@ trait RevisionableTrait
         $additional = [];
         //Determine if there are any additional fields we'd like to add to our model contained in the config file, and
         //get them into an array.
-        $fields = $this->getAdditionalFieldNames();
-        foreach($fields as $field)
-        {
-            if(Arr::has($this->originalData, $field))
-            {
+        $fields = config('revisionable.additional_fields', []);
+        foreach($fields as $field) {
+            if(Arr::has($this->originalData, $field)) {
                 $additional[$field]  =  Arr::get($this->originalData, $field);
             }
         }
 
         return $additional;
-    }
-
-
-    /**
-     * Get any fields that should be included in the revision model that have been selected in
-     * config/revisionable.php
-     *
-     * @return array fields
-     */
-    public function getAdditionalFieldNames()
-    {
-        if(config('revisionable.additional_fields_in_model', null) != null) {
-
-            $fields = config('revisionable.additional_fields_in_model', null);
-            $fields = explode('|', $fields);
-            return $fields;
-        }
-
-        return [];
     }
 
     /**

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -126,7 +126,7 @@ trait RevisionableTrait
             // we can only safely compare basic items,
             // so for now we drop any object based items, like DateTime
             foreach ($this->updatedData as $key => $val) {
-                if (isset($this->casts[$key]) && in_array($this->casts[$key], ['object', 'array']) && isset($this->originalData[$key])) {
+                if (gettype($val) == 'object' && isset($this->casts[$key]) && in_array($this->casts[$key], ['object', 'array']) && isset($this->originalData[$key])) {
                     // Sorts the keys of a JSON object due Normalization performed by MySQL
                     // So it doesn't set false flag if it is changed only order of key or whitespace after comma
 

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -126,7 +126,7 @@ trait RevisionableTrait
             // we can only safely compare basic items,
             // so for now we drop any object based items, like DateTime
             foreach ($this->updatedData as $key => $val) {
-				$castCheck = ['object', 'array'];
+                $castCheck = ['object', 'array'];
                 if (isset($this->casts[$key]) && in_array(gettype($val), $castCheck) && in_array($this->casts[$key], $castCheck) && isset($this->originalData[$key])) {
                     // Sorts the keys of a JSON object due Normalization performed by MySQL
                     // So it doesn't set false flag if it is changed only order of key or whitespace after comma

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -126,7 +126,8 @@ trait RevisionableTrait
             // we can only safely compare basic items,
             // so for now we drop any object based items, like DateTime
             foreach ($this->updatedData as $key => $val) {
-                if (gettype($val) == 'object' && isset($this->casts[$key]) && in_array($this->casts[$key], ['object', 'array']) && isset($this->originalData[$key])) {
+				$castCheck = ['object', 'array'];
+                if (isset($this->casts[$key]) && in_array(gettype($val), $castCheck) && in_array($this->casts[$key], $castCheck) && isset($this->originalData[$key])) {
                     // Sorts the keys of a JSON object due Normalization performed by MySQL
                     // So it doesn't set false flag if it is changed only order of key or whitespace after comma
 

--- a/src/config/revisionable.php
+++ b/src/config/revisionable.php
@@ -7,4 +7,7 @@ return [
     |--------------------------------------------------------------------------
     */
     'model' => Venturecraft\Revisionable\Revision::class,
+
+    'additional_fields' => [],
+
 ];

--- a/src/migrations/2013_04_09_062329_create_revisions_table.php
+++ b/src/migrations/2013_04_09_062329_create_revisions_table.php
@@ -12,10 +12,10 @@ class CreateRevisionsTable extends Migration
     public function up()
     {
         Schema::create('revisions', function ($table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('revisionable_type');
-            $table->integer('revisionable_id');
-            $table->integer('user_id')->nullable();
+            $table->unsignedBigInteger('revisionable_id');
+            $table->unsignedBigInteger('user_id')->nullable();
             $table->string('key');
             $table->text('old_value')->nullable();
             $table->text('new_value')->nullable();
@@ -32,6 +32,6 @@ class CreateRevisionsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('revisions');
+        Schema::dropIfExists('revisions');
     }
 }

--- a/src/migrations/2013_04_09_062329_create_revisions_table.php
+++ b/src/migrations/2013_04_09_062329_create_revisions_table.php
@@ -14,17 +14,11 @@ class CreateRevisionsTable extends Migration
         Schema::create('revisions', function ($table) {
             $table->bigIncrements('id');
             $table->string('revisionable_type');
-<<<<<<< HEAD
             $table->integer('revisionable_id');
             $table->string('transaction_id');
             $table->string('ip_address');
             $table->integer('user_id')->nullable();
             $table->string('field');
-=======
-            $table->unsignedBigInteger('revisionable_id');
-            $table->unsignedBigInteger('user_id')->nullable();
-            $table->string('key');
->>>>>>> upstream/master
             $table->text('old_value')->nullable();
             $table->text('new_value')->nullable();
             $table->timestamps();

--- a/tests/migrations/2020_01_02_062329_add_additional_field_to_revisions.php
+++ b/tests/migrations/2020_01_02_062329_add_additional_field_to_revisions.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddAdditionalFieldToRevisions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('revisions', function (Blueprint $table) {
+            $table->string('additional_field')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/tests/migrations/2020_01_02_062330_add_additional_field_to_users.php
+++ b/tests/migrations/2020_01_02_062330_add_additional_field_to_users.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddAdditionalFieldToUsers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('additional_field')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
This PR updates the Revisionable-1 fork of Revisionable to the latest on the main repo. This update allows Laravel 7 and 8 and adds two features: the ability to record forceDeletes as revisions, and additional fields that can be recorded as metadata for revisions. Jitterbug will likely utilize neither of these features.